### PR TITLE
push-to-gar-docker: support load

### DIFF
--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -82,6 +82,11 @@ inputs:
     description: |
       Secrets to expose to the build. Only needed when authenticating to private repositories outside the repository in which the image is being built.
     required: false
+  load:
+    description: |
+      Whether to load the built image into the local docker daemon.
+    required: false
+    default: "false"
 
 outputs:
   version:
@@ -198,6 +203,7 @@ runs:
         ssh: ${{ inputs.ssh }}
         build-contexts: ${{ inputs.build-contexts }}
         secrets: ${{ inputs.secrets }}
+        load: ${{ inputs.load == 'true' }}
 
     - name: Cleanup checkout directory
       if: ${{ !cancelled() }}


### PR DESCRIPTION
This adds support for providing the `load` parameter to `docker/build-push-action` which allows the image to be loaded in to the docker daemon. 

We want to load the image in to the docker daemon to easier support exporting it (https://github.com/grafana/cloud-onboarding/blob/0b903cb4fdaabc32f1482f49afff6ee66745ed5c/.github/workflows/service.yml#L81-L119) so we can load it in to k3d to run integration tests against it. 